### PR TITLE
feat: support multiple controls

### DIFF
--- a/projects/demo/src/app/mdc/mdc.component.html
+++ b/projects/demo/src/app/mdc/mdc.component.html
@@ -3,7 +3,7 @@
     <mat-card-title> Reactive forms </mat-card-title>
   </mat-card-header>
   <mat-card-content>
-    <p>Error message outside of a <code>mat-form-field</code>.</p>
+    <!-- <p>Error message outside of a <code>mat-form-field</code>.</p>
     <mat-error [ngx-mat-errors]="input1">
       <span *ngxMatErrorDef="let error; for: 'pattern'">
         Only digits are allowed, up to 2 digits. Error: {{ error | json }}
@@ -44,10 +44,28 @@
         </ng-container>
       </mat-error>
       <mat-hint>Min value is 10, max is 20</mat-hint>
+    </mat-form-field> -->
+    <mat-form-field appearance="outline">
+      <mat-label>Daterange picker</mat-label>
+      <mat-date-range-input [dateFilter]="filter" [rangePicker]="picker">
+        <input matStartDate [formControl]="start" placeholder="Start date" />
+        <input matEndDate [formControl]="end" placeholder="End date" />
+      </mat-date-range-input>
+      <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
+      <mat-datepicker-toggle
+        matIconSuffix
+        [for]="picker"
+      ></mat-datepicker-toggle>
+      <mat-date-range-picker #picker></mat-date-range-picker>
+      <mat-error [ngx-mat-errors]="[start, end]"
+        ><ng-container *ngxMatErrorDef="let error; for: 'matDatepickerFilter'">
+          end
+        </ng-container></mat-error
+      >
     </mat-form-field>
   </mat-card-content>
 </mat-card>
-<mat-card>
+<!-- <mat-card>
   <mat-card-header>
     <mat-card-title>Template driven forms</mat-card-title>
   </mat-card-header>
@@ -99,4 +117,4 @@
       <mat-hint>Min value is 10, max is 20</mat-hint>
     </mat-form-field>
   </mat-card-content>
-</mat-card>
+</mat-card> -->

--- a/projects/demo/src/app/mdc/mdc.component.ts
+++ b/projects/demo/src/app/mdc/mdc.component.ts
@@ -1,12 +1,16 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
-import { FormControl, Validators } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+} from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: 'app-mdc',
   templateUrl: './mdc.component.html',
   styleUrls: ['./mdc.component.scss'],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdcComponent {
   readonly control1 = new FormControl<string>('', [
@@ -17,6 +21,10 @@ export class MdcComponent {
     Validators.min(10),
     Validators.max(20),
   ]);
+  readonly start = new FormControl<Date | null>(null, Validators.required);
+  readonly end = new FormControl<Date | null>(null, Validators.required);
+
+  filter = () => false;
 
   value1: string | null = null;
   value2: number | null = null;

--- a/projects/demo/src/app/mdc/mdc.module.ts
+++ b/projects/demo/src/app/mdc/mdc.module.ts
@@ -6,8 +6,10 @@ import { MdcComponent } from './mdc.component';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatInputModule } from '@angular/material/input';
 import { NgxMatErrors, NgxMatErrorDef } from 'ngx-mat-errors';
+import { MatNativeDateModule } from '@angular/material/core';
 
 @NgModule({
   declarations: [MdcComponent],
@@ -16,6 +18,8 @@ import { NgxMatErrors, NgxMatErrorDef } from 'ngx-mat-errors';
     MdcRoutingModule,
     MatFormFieldModule,
     MatInputModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     NgxMatErrors,
     NgxMatErrorDef,
     MatCardModule,

--- a/projects/ngx-mat-errors/src/lib/error-messages.ts
+++ b/projects/ngx-mat-errors/src/lib/error-messages.ts
@@ -1,4 +1,3 @@
-
 export type ErrorTransform = (error: any) => string;
 
 export interface ErrorMessages {
@@ -24,3 +23,17 @@ export interface PatternValidator {
   requiredPattern: string;
   actualValue: string;
 }
+
+export interface StartDateError {
+  end: string | Date;
+  actual: string | Date;
+}
+export interface EndDateError {
+  actual: string | Date;
+  start: string | Date;
+}
+
+export interface DatepickerParseError {
+  text: string;
+}
+

--- a/projects/ngx-mat-errors/src/lib/locales/en.ts
+++ b/projects/ngx-mat-errors/src/lib/locales/en.ts
@@ -1,6 +1,14 @@
 import { formatDate } from '@angular/common';
 import { FactoryProvider, LOCALE_ID } from '@angular/core';
-import { ErrorMessages, LengthError, MaxError, MinError } from '../error-messages';
+import {
+  DatepickerParseError,
+  EndDateError,
+  ErrorMessages,
+  LengthError,
+  MaxError,
+  MinError,
+  StartDateError,
+} from '../error-messages';
 import { NGX_MAT_ERROR_DEFAULT_OPTIONS } from '../ngx-mat-errors.component';
 
 export function errorMessagesEnFactory(
@@ -30,6 +38,20 @@ export function errorMessagesEnFactory(
         formatted ?? error.max
       }.`;
     },
+    matStartDateInvalid: (error: StartDateError) => {
+      const formatted = formatDate(error.end, format, locale);
+      return `Please enter a start date less than or equal to ${
+        formatted ?? error.end
+      }.`;
+    },
+    matEndDateInvalid: (error: EndDateError) => {
+      const formatted = formatDate(error.start, format, locale);
+      return `Please enter an end date greater than or equal to ${
+        formatted ?? error.start
+      }.`;
+    },
+    matDatepickerParse: (error: DatepickerParseError) =>
+      `Date '${error.text}' is invalid.`,
   };
 }
 

--- a/projects/ngx-mat-errors/src/lib/locales/hu.ts
+++ b/projects/ngx-mat-errors/src/lib/locales/hu.ts
@@ -1,9 +1,20 @@
 import { formatDate } from '@angular/common';
 import { FactoryProvider, LOCALE_ID } from '@angular/core';
-import { ErrorMessages, LengthError, MaxError, MinError } from '../error-messages';
+import {
+  DatepickerParseError,
+  EndDateError,
+  ErrorMessages,
+  LengthError,
+  MaxError,
+  MinError,
+  StartDateError,
+} from '../error-messages';
 import { NGX_MAT_ERROR_DEFAULT_OPTIONS } from '../ngx-mat-errors.component';
 
-export function errorMessagesHuFactory(locale: string, format = 'shortDate'): ErrorMessages {
+export function errorMessagesHuFactory(
+  locale: string,
+  format = 'shortDate'
+): ErrorMessages {
   return {
     min: (error: MinError) => `Nem lehet kisebb, mint ${error.min}.`,
     max: (error: MaxError) => `Nem lehet nagyobb, mint ${error.max}.`,
@@ -24,11 +35,25 @@ export function errorMessagesHuFactory(locale: string, format = 'shortDate'): Er
       // In Hungarian date ends with '.'
       return `Nem lehet későbbi dátum, mint ${formatted ?? error.max}`;
     },
+    matStartDateInvalid: (error: StartDateError) => {
+      const formatted = formatDate(error.end, format, locale);
+      return `Nem lehet a kezdő dátum későbbi, mint ${
+        formatted ?? error.end
+      }.`;
+    },
+    matEndDateInvalid: (error: EndDateError) => {
+      const formatted = formatDate(error.start, format, locale);
+      return `Nem lehet a vég dátum korábbi, mint ${
+        formatted ?? error.start
+      }.`;
+    },
+    matDatepickerParse: (error: DatepickerParseError) =>
+      `A dátum '${error.text}' érvénytelen.`,
   };
 }
 
 export const NGX_MAT_ERROR_CONFIG_HU: FactoryProvider = {
   provide: NGX_MAT_ERROR_DEFAULT_OPTIONS,
   useFactory: errorMessagesHuFactory,
-  deps: [LOCALE_ID]
+  deps: [LOCALE_ID],
 };


### PR DESCRIPTION
Adds support to bind multiple controls to an error component as an array of `AbstractControls`. 